### PR TITLE
Documents section

### DIFF
--- a/gatsby-site/src/components/About.js
+++ b/gatsby-site/src/components/About.js
@@ -1,23 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 import styled from "styled-components"
-
-const Section = styled.section`
-  position: relative;
-  overflow: hidden;
-`
-
-const Heading = styled.h2`
-  font-style: normal;
-  font-weight: bold;
-  font-size: 16px;
-  line-height: 1.25;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--sunrise-gray);
-  padding-bottom: 16px;
-  margin: 0;
-`
+import Section from "./Section"
 
 const Body = styled.div`
   font-family: var(--sunrise-font-serif);
@@ -43,8 +27,7 @@ const Paragraph = styled.p`
  */
 const About = ({ hubName, content }) => {
   return (
-    <Section>
-      <Heading>About Sunrise {hubName}</Heading>
+    <Section id="about" title={`About Sunrise ${hubName}`}>
       <Body>
         {content
           .split(/\n\n+/)

--- a/gatsby-site/src/components/Documents.js
+++ b/gatsby-site/src/components/Documents.js
@@ -1,0 +1,98 @@
+import React from "react"
+import Section from "./Section"
+import styled from "styled-components"
+
+const Grid = styled.div`
+  display: grid;
+  grid-column-gap: 20px;
+  grid-row-gap: 20px;
+  grid-template-columns: 1fr 1fr;
+  grid-auto-flow: dense;
+`
+
+const DownloadLink = styled.a`
+  display: flex;
+  padding: 20px;
+  align-items: center;
+  justify-content: space-between;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 12px;
+  line-height: 15px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--sunrise-gray);
+  fill: currentColor;
+  stroke: currentColor;
+  background-color: var(--sunrise-tan);
+  text-decoration: none;
+`
+
+/**
+ * @type {React.ReactNode}
+ */
+const icon = (
+  <svg width="13" height="17" viewBox="0 0 13 17">
+    <rect
+      x="0.619048"
+      y="1.38077"
+      width="11.7619"
+      height="14.2381"
+      rx="1.85714"
+      strokeWidth="1.2381"
+      fill="none"
+    />
+    <rect
+      x="2.4762"
+      y="4.47614"
+      width="8.04762"
+      height="1.2381"
+      stroke="none"
+    />
+    <rect
+      x="2.4762"
+      y="7.57135"
+      width="8.04762"
+      height="1.2381"
+      stroke="none"
+    />
+    <rect
+      x="2.4762"
+      y="10.6666"
+      width="5.57143"
+      height="1.2381"
+      stroke="none"
+    />
+  </svg>
+)
+
+/**
+ * @typedef {Object} Document
+ * @property {string} id
+ * @property {string} publicURL
+ * @property {string} name
+ *
+ * @typedef {Object} DocumentsProps
+ * @property {Array<Document>} documents
+ *
+ * @param {DocumentsProps} props
+ */
+const Documents = ({ documents }) => {
+  return (
+    <Section id="documents" title="Documents">
+      <Grid>
+        {documents.map(document => (
+          <DownloadLink
+            target="_blank"
+            key={document.publicURL}
+            href={document.publicURL}>
+            <span>{document.name}</span>
+            {icon}
+          </DownloadLink>
+        ))}
+      </Grid>
+    </Section>
+  )
+}
+
+export default Documents

--- a/gatsby-site/src/components/Section.js
+++ b/gatsby-site/src/components/Section.js
@@ -1,0 +1,38 @@
+import React from "react"
+import styled from "styled-components"
+
+const Container = styled.section`
+  position: relative;
+  overflow: hidden;
+`
+
+const Heading = styled.h2`
+  font-style: normal;
+  font-weight: bold;
+  font-size: 16px;
+  line-height: 1.25;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--sunrise-gray);
+  padding-bottom: 20px;
+  margin: 0;
+`
+
+/**
+ * @typedef {Object} SectionProps
+ * @property {string} id
+ * @property {string} title
+ * @property {React.ReactNode} children
+ *
+ * @param {SectionProps} props
+ */
+const Section = ({ id, title, children }) => {
+  return (
+    <Container>
+      <Heading id={id}>{title}</Heading>
+      <div>{children}</div>
+    </Container>
+  )
+}
+
+export default Section

--- a/gatsby-site/src/components/global.css
+++ b/gatsby-site/src/components/global.css
@@ -5,6 +5,7 @@
   --sunrise-orange: #FD9014;
   --sunrise-red: #EF4C39;
   --sunrise-yellow: #FFDE16;
+  --sunrise-tan: #F7F5E8;
   --sunrise-font-sans: Source Sans Prop;
   --sunrise-font-serif: Source Serif Pro;
 }

--- a/gatsby-site/src/components/layout.css
+++ b/gatsby-site/src/components/layout.css
@@ -185,7 +185,7 @@ textarea {
   font: inherit;
 }
 html {
-  font: 112.5%/1.45em georgia, serif;
+  font: 112.5%/1.45em Source Sans Pro;
   box-sizing: border-box;
   overflow-y: scroll;
 }
@@ -200,7 +200,6 @@ html {
 }
 body {
   color: hsla(0, 0%, 0%, 0.8);
-  font-family: georgia, serif;
   font-weight: normal;
   word-wrap: break-word;
   font-kerning: normal;
@@ -219,8 +218,6 @@ h1 {
   padding-top: 0;
   margin-bottom: 1.45rem;
   color: inherit;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
   font-weight: bold;
   text-rendering: optimizeLegibility;
   font-size: 2.25rem;
@@ -236,8 +233,6 @@ h2 {
   padding-top: 0;
   margin-bottom: 1.45rem;
   color: inherit;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
   font-weight: bold;
   text-rendering: optimizeLegibility;
   font-size: 1.62671rem;
@@ -253,8 +248,6 @@ h3 {
   padding-top: 0;
   margin-bottom: 1.45rem;
   color: inherit;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
   font-weight: bold;
   text-rendering: optimizeLegibility;
   font-size: 1.38316rem;
@@ -270,8 +263,6 @@ h4 {
   padding-top: 0;
   margin-bottom: 1.45rem;
   color: inherit;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
   font-weight: bold;
   text-rendering: optimizeLegibility;
   font-size: 1rem;
@@ -287,8 +278,6 @@ h5 {
   padding-top: 0;
   margin-bottom: 1.45rem;
   color: inherit;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
   font-weight: bold;
   text-rendering: optimizeLegibility;
   font-size: 0.85028rem;
@@ -304,8 +293,6 @@ h6 {
   padding-top: 0;
   margin-bottom: 1.45rem;
   color: inherit;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
   font-weight: bold;
   text-rendering: optimizeLegibility;
   font-size: 0.78405rem;
@@ -581,8 +568,6 @@ tt,
 code {
   background-color: hsla(0, 0%, 0%, 0.04);
   border-radius: 3px;
-  font-family: "SFMono-Regular", Consolas, "Roboto Mono", "Droid Sans Mono",
-    "Liberation Mono", Menlo, Courier, monospace;
   padding: 0;
   padding-top: 0.2em;
   padding-bottom: 0.2em;

--- a/gatsby-site/src/pages/index.js
+++ b/gatsby-site/src/pages/index.js
@@ -41,6 +41,11 @@ const IndexPage = ({ data }) => {
 export default IndexPage
 
 /**
+ * @typedef {Object} Document
+ * @property {string} id
+ * @property {string} name
+ * @property {string} publicURL
+ *
  * @typedef {Object} PageQuery
  * @property {Object} hub
  * @property {string} hub.name
@@ -50,6 +55,7 @@ export default IndexPage
  * @property {import("gatsby-image").GatsbyImageProps} hub.logo.childImageSharp
  * @property {Object} hub.hero
  * @property {import("gatsby-image").GatsbyImageProps} hub.hero.childImageSharp
+ * @property {Array<Document>} hub.documents
  * @property {Object} defaultLogo
  * @property {import("gatsby-image").GatsbyImageProps} defaultLogo.childImageSharp
  * @property {Object} defaultHero
@@ -95,6 +101,11 @@ export const pageQuery = graphql`
             ...GatsbyImageSharpFluid
           }
         }
+      }
+      documents {
+        id
+        name
+        publicURL
       }
     }
   }

--- a/gatsby-site/src/pages/index.js
+++ b/gatsby-site/src/pages/index.js
@@ -3,12 +3,16 @@ import styled from "styled-components"
 import Layout from "../components/layout"
 import Hero from "../components/Hero"
 import About from "../components/About"
+import Documents from "../components/Documents"
 import { graphql } from "gatsby"
 
 const MainContent = styled.div`
   max-width: 756px;
   padding: 80px 16px;
   margin: 0 auto;
+  display: grid;
+  grid-auto-flow: row;
+  grid-row-gap: 80px;
 `
 
 /**
@@ -33,6 +37,7 @@ const IndexPage = ({ data }) => {
       />
       <MainContent>
         <About hubName={data.hub.name} content={data.hub.about} />
+        <Documents documents={data.hub.documents} />
       </MainContent>
     </Layout>
   )


### PR DESCRIPTION
Adds the documents section, and also splits out the section layout into a new component

No preview link until the base for the PR is switched to master

<img width="783" alt="Screen Shot 2020-05-19 at 9 25 35 AM" src="https://user-images.githubusercontent.com/1508245/82352388-be0d6a00-99b2-11ea-89cd-8e462f9b885f.png">
