### PR TITLE
Add an index page that redirects to the national site

### DIFF
--- a/gatsby-site/src/pages/index.js
+++ b/gatsby-site/src/pages/index.js
@@ -1,0 +1,17 @@
+import React from "react"
+import Helmet from "react-helmet"
+
+export default () => {
+  return (
+    <>
+      <Helmet>
+        <meta
+          httpEquiv="refresh"
+          content="0; URL=https://sunrisemovement.org/hubs"
+        />
+        <link rel="canonical" href="https://sunrisemovement.org/hubs" />
+      </Helmet>
+      <div>Redirecting...</div>
+    </>
+  )
+}


### PR DESCRIPTION
The http-equiv="refresh" attribute tells the browser to reload the page. You can supply some parameters to this meta action in the content attribute:
- the first parameter is the number of milliseconds before the refresh should happen. This was originally intended for things like old-school refreshing to keep live data up to date. We can set it to 0 to make it immediate.
- The second is the URL to load on reload.

We must also set the canonical URL using a link tag so that search engine crawlers and the like know that this isn't actually a unique page.

This whole thing approximates a server-side redirect, all while using a static site!