### PR TITLE
Minimal CSS changes to fix event display

### DIFF
--- a/gatsby-site/src/components/Events.js
+++ b/gatsby-site/src/components/Events.js
@@ -8,6 +8,7 @@ const Layout = styled.div`
   grid-auto-flow: column;
   grid-row-gap: 20px;
   grid-column-gap: 20px;
+  overflow-x: scroll;
 
   @media (max-width: 768px) {
     grid-template-columns: 1fr;
@@ -58,6 +59,7 @@ const InfoLink = styled.a`
   padding: 10px 28px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
+  white-space: nowrap;
 `
 
 const formatDateForDisplay = input => {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1022564/84651400-e1570680-aed7-11ea-9f46-bceed29fd8d4.png)
After:
![fofsdf](https://user-images.githubusercontent.com/1022564/84651462-00ee2f00-aed8-11ea-93ec-f251a229d2b4.gif)
Note that the columns still seem a tiny bit uneven, might be good to tweak (not sure how css grid works though ._.)
