### PR TITLE
Add alternative way to trigger Gatsby publish

### DIFF
--- a/.github/workflows/gatsby-publish.yml
+++ b/.github/workflows/gatsby-publish.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - master
+  repository_dispatch:
+    types: deploy
 
 jobs:
   build:


### PR DESCRIPTION
See <https://goobar.io/manually-trigger-a-github-actions-workflow>; this should let us trigger Gatsby deploys via the API, for real this time!

Related PR: https://github.com/sunrisemovement/hubhub/pull/18